### PR TITLE
fix: correct image captions for programs

### DIFF
--- a/src/app/components/Program.tsx
+++ b/src/app/components/Program.tsx
@@ -32,7 +32,7 @@ export default function Program({
         draggable="false"
         className="select-none"
         src={`/banners/programs/${image}`}
-        alt="Advent of Code"
+        alt={name}
       />
     </Link>
   );


### PR DESCRIPTION
Fix issue where image captions in the "programs" section were incorrectly set to the hard-coded string value of "Advent of Code" instead of reflecting their respective names.